### PR TITLE
Add Go Modules Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+dogstatsd-local

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/jonmorehouse/dogstatsd-local
+
+go 1.20


### PR DESCRIPTION
This commit introduces Go Modules to the project. This makes the project build on GO later than 1.16 and fixes the error:

```
go: cannot find main module, but found .git/config in
/export/dogstatsd-local
  to create a module there, run:
  go mod init
```

The following files have been added:

- `go.mod`: This file is used by Go to manage project dependencies. It was created by running `go mod init` and `go mod tidy`, which automatically identified the project's dependencies and added them to the file.

- `.gitignore`: This file has been added to prevent certain the binary from being tracked by Git.

Please note that Go 1.11 or later is required to build the project with Go Modules.